### PR TITLE
fix: improve input text color for better readability (#38)

### DIFF
--- a/app/components/ui/form/input.tsx
+++ b/app/components/ui/form/input.tsx
@@ -3,7 +3,7 @@ import { type InputHTMLAttributes, forwardRef, type ReactNode } from 'react'
 import { type VariantProps, cva, cx } from 'class-variance-authority'
 
 const inputVariants = cva(
-  'flex w-full aria-[invalid]:border-destructive rounded-lg text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-placeholder placeholder:font-light disabled:cursor-not-allowed',
+  'flex w-full text-foreground aria-[invalid]:border-destructive rounded-lg text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-placeholder placeholder:font-light disabled:cursor-not-allowed',
   {
     variants: {
       variant: {

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -5,7 +5,7 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 210 40% 98%;
+    --foreground: 222.2 47.4% 11.2%;
     --primary: 0 0% 13%;
     --muted: 215 19% 35%;
     --border: 179 46% 55%;


### PR DESCRIPTION
### Context

- fixes #38

On the Extension page (https://interledgerpay.com/extension/), the input fields had text that was too light, making it hard to read.

### Changes

- Updated the input text color to improve readability.
- Ensured consistency with the overall design and accessibility standards.
- Verified that the change works across light and dark modes.
